### PR TITLE
fix: Fix check for mask IFD

### DIFF
--- a/src/async_geotiff/_geotiff.py
+++ b/src/async_geotiff/_geotiff.py
@@ -6,9 +6,10 @@ from typing import TYPE_CHECKING, Literal, Self
 
 from affine import Affine
 from async_tiff import TIFF
+from async_tiff.enums import PhotometricInterpretation
 
 from async_geotiff._overview import Overview
-from async_geotiff.enums import Compression, Interleaving, PhotometricInterp
+from async_geotiff.enums import Compression, Interleaving
 
 if TYPE_CHECKING:
     import pyproj
@@ -383,8 +384,9 @@ def is_mask_ifd(ifd: ImageFileDirectory) -> bool:
     """Check if an IFD is a mask IFD."""
     if (
         ifd.compression == Compression.deflate
-        and ifd.new_subfile_type
-        and ifd.photometric_interpretation == 4
+        and ifd.new_subfile_type is not None
+        and ifd.new_subfile_type & 4 != 0
+        and ifd.photometric_interpretation == PhotometricInterpretation.TransparencyMask
     ):
         return True
 


### PR DESCRIPTION
I'm pretty sure this is correct given https://github.com/geospatial-jeff/aiocogeo/blob/5a1d32c3f22c883354804168a87abb0a2ea1c328/aiocogeo/ifd.py#L30-L45

https://github.com/developmentseed/async-geotiff/issues/11 tracks creating a test for this once we have a file in `geotiff-test-data` with internal masks.