### PR TITLE
fix: Fix ordering of tile matrices in TileMatrixSet

### DIFF
--- a/tests/test_tms.py
+++ b/tests/test_tms.py
@@ -30,17 +30,6 @@ async def test_tms(load_geotiff: LoadGeoTIFF) -> None:
     assert tms_dict["tileMatrices"] == [
         {
             "id": "0",
-            "scaleDenominator": 3975696.099759771,
-            "cellSize": 0.01,
-            "cornerOfOrigin": "topLeft",
-            "pointOfOrigin": (0.0, 0.0),
-            "tileWidth": 64,
-            "tileHeight": 64,
-            "matrixWidth": 2,
-            "matrixHeight": 2,
-        },
-        {
-            "id": "1",
             "scaleDenominator": 7951392.199519542,
             "cellSize": 0.02,
             "cornerOfOrigin": "topLeft",
@@ -49,5 +38,16 @@ async def test_tms(load_geotiff: LoadGeoTIFF) -> None:
             "tileHeight": 64,
             "matrixWidth": 1,
             "matrixHeight": 1,
+        },
+        {
+            "id": "1",
+            "scaleDenominator": 3975696.099759771,
+            "cellSize": 0.01,
+            "cornerOfOrigin": "topLeft",
+            "pointOfOrigin": (0.0, 0.0),
+            "tileWidth": 64,
+            "tileHeight": 64,
+            "matrixWidth": 2,
+            "matrixHeight": 2,
         },
     ]


### PR DESCRIPTION
As discussed in [this thread](https://github.com/developmentseed/async-geotiff/pull/18#discussion_r2734141868), it is intended that the tile matrices are ordered from coarsest (fewest tiles that cover the image) to finest (highest resolution).

This PR fixes the ordering.