### PR TITLE
fix(docs): Fix hot reloading of mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,9 +93,6 @@ plugins:
         python:
           paths: [src]
           options:
-            # We set allow_inspection: false to ensure that all docstrings come
-            # from the pyi files, not the Rust-facing doc comments.
-            allow_inspection: false
             docstring_section_style: list
             docstring_style: google
             inherited_members: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dev = [
     "types-jsonschema>=4.26.0.20260109",
 ]
 docs = [
+    # Workaround for https://github.com/mkdocs/mkdocs/issues/4032
+    "click<8.3",
     "mkdocs-material[imaging]>=9.5.49",
     "mkdocs>=1.6.1",
     "mkdocstrings[python]>=1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,7 @@ dev = [
 ]
 docs = [
     { name = "black" },
+    { name = "click" },
     { name = "griffe-inherited-docstrings" },
     { name = "mike" },
     { name = "mkdocs" },
@@ -111,6 +112,7 @@ dev = [
 ]
 docs = [
     { name = "black", specifier = ">=26" },
+    { name = "click", specifier = "<8.3" },
     { name = "griffe-inherited-docstrings", specifier = ">=1.0.1" },
     { name = "mike", specifier = ">=2.1.3" },
     { name = "mkdocs", specifier = ">=1.6.1" },
@@ -410,14 +412,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
See https://github.com/mkdocs/mkdocs/issues/4032

We pin click to <8.3 to fix hot reloading.