### PR TITLE
feat: Cleanup pass for 0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Fast, async GeoTIFF and [Cloud-Optimized GeoTIFF][cogeo] (COG) reader for Python
 
 ## Features
 
-- Read-only support for **GeoTIFF and COG** formats.
-- High-level, familiar, **easy to use** API.
+- Asynchronous, read-only support for **GeoTIFF and COG** formats.
+- **High-level**, familiar, **easy to use** API.
+    - Integration with [NumPy], [Affine], and [PyProj].
+    - Access to full-resolution image and reduced-resolution overviews.
+    - Support for nodata values and nodata masks.
 - **Performance-focused**:
     - Rust core ensures native performance.
     - CPU-bound tasks like image decoding happen in a thread pool, without blocking the async executor.
@@ -22,12 +25,17 @@ Fast, async GeoTIFF and [Cloud-Optimized GeoTIFF][cogeo] (COG) reader for Python
 - **Full type hinting** for all operations.
 - **Broad decompression support**: Deflate, LZW, JPEG, JPEG2000, WebP, ZSTD.
 
+[Affine]: https://affine.readthedocs.io/en/latest/
+[NumPy]: https://numpy.org/
+[PyProj]: https://pyproj4.github.io/pyproj/stable/
+
 #### Anti-Features
 
 _Features explicitly not in scope_:
 
 - No pixel resampling.
 - No warping/reprojection.
+- Automatic resolution/overview selection
 
 Resampling and warping bring significant additional complexity and are out of scope for this library. Consider using `async-geotiff` to load data, then [rasterio]'s [In-Memory Files] to resample or reproject data, if needed.
 

--- a/src/async_geotiff/_overview.py
+++ b/src/async_geotiff/_overview.py
@@ -84,15 +84,15 @@ class Overview(ReadMixin, FetchTileMixin, TransformMixin):
     @property
     def tile_height(self) -> int:
         """The height in pixels per tile of the overview."""
-        return self._ifd.tile_height or self.height
+        return self._geotiff.tile_height
 
     @property
     def tile_width(self) -> int:
         """The width in pixels per tile of the overview."""
-        return self._ifd.tile_width or self.width
+        return self._geotiff.tile_width
 
     @property
-    def transform(self) -> Affine:  # type: ignore[override]
+    def transform(self) -> Affine:
         """The affine transform mapping pixel coordinates to geographic coordinates.
 
         Returns:

--- a/src/async_geotiff/enums.py
+++ b/src/async_geotiff/enums.py
@@ -1,6 +1,6 @@
 """Enums used by async_geotiff."""
 
-from enum import Enum, IntEnum
+from enum import Enum
 
 # ruff: noqa: D101
 
@@ -13,47 +13,39 @@ class Compression(Enum):
     in this enum.
     """
 
-    jpeg = "JPEG"
-    lzw = "LZW"
-    packbits = "PACKBITS"
-    deflate = "DEFLATE"
-    ccittrle = "CCITTRLE"
-    ccittfax3 = "CCITTFAX3"
-    ccittfax4 = "CCITTFAX4"
-    lzma = "LZMA"
-    none = "NONE"
-    zstd = "ZSTD"
-    lerc = "LERC"
-    lerc_deflate = "LERC_DEFLATE"
-    lerc_zstd = "LERC_ZSTD"
-    webp = "WEBP"
-    jpeg2000 = "JPEG2000"
+    JPEG = "JPEG"
+    LZW = "LZW"
+    PACKBITS = "PACKBITS"
+    DEFLATE = "DEFLATE"
+    CCITTRLE = "CCITTRLE"
+    CCITTFAX3 = "CCITTFAX3"
+    CCITTFAX4 = "CCITTFAX4"
+    LZMA = "LZMA"
+    NONE = "NONE"
+    ZSTD = "ZSTD"
+    LERC = "LERC"
+    LERC_DEFLATE = "LERC_DEFLATE"
+    LERC_ZSTD = "LERC_ZSTD"
+    WEBP = "WEBP"
+    JPEG2000 = "JPEG2000"
+    UNCOMPRESSED = "UNCOMPRESSED"
 
 
 # https://github.com/rasterio/rasterio/blob/2d79e5f3a00e919ecaa9573adba34a78274ce48c/rasterio/enums.py#L177-L182
 class Interleaving(Enum):
-    pixel = "PIXEL"
-    line = "LINE"
-    band = "BAND"
-    #: tile requires GDAL 3.11+
-    tile = "TILE"
-
-
-# https://github.com/rasterio/rasterio/blob/2d79e5f3a00e919ecaa9573adba34a78274ce48c/rasterio/enums.py#L185-L189
-class MaskFlags(IntEnum):
-    all_valid = 1
-    per_dataset = 2
-    alpha = 4
-    nodata = 8
+    PIXEL = "PIXEL"
+    BAND = "BAND"
+    # TODO: Support GDAL's new TILE interleaving option
+    # https://gdal.org/en/stable/drivers/raster/cog.html#general-creation-options
 
 
 # https://github.com/rasterio/rasterio/blob/2d79e5f3a00e919ecaa9573adba34a78274ce48c/rasterio/enums.py#L192-L200
-class PhotometricInterp(Enum):
-    black = "MINISBLACK"
-    white = "MINISWHITE"
-    rgb = "RGB"
-    cmyk = "CMYK"
-    ycbcr = "YCbCr"
-    cielab = "CIELAB"
-    icclab = "ICCLAB"
-    itulab = "ITULAB"
+class PhotometricInterpretation(Enum):
+    WHITE_IS_ZERO = "MINISWHITE"
+    BLACK_IS_ZERO = "MINISBLACK"
+    RGB = "RGB"
+    RGBPALETTE = "PALETTE"
+    TRANSPARENCY_MASK = "MASK"
+    CMYK = "CMYK"
+    YCBCR = "YCbCr"
+    CIELAB = "CIELAB"


### PR DESCRIPTION
### Change list

- Removes `block_shapes` method (use `tile_height` and `tile_width` instead)
- Removes `block_size` method
- Comments out `colorinterp` attribute
- Implements `compression`, `count`, `dtype`, `interleaving`, `is_tiled`, `photometric`
- Updates enums to have upper case member values (pending final decision in #61 )
- Readme updates


Closes:

- Closes https://github.com/developmentseed/async-geotiff/issues/55
- Closes https://github.com/developmentseed/async-geotiff/issues/12 (for now we use string values matching rasterio)
- Closes https://github.com/developmentseed/async-geotiff/issues/20 (`dtype` returns a `np.dtype`)
- Closes https://github.com/developmentseed/async-geotiff/issues/15 (removes `block_size` method)