### PR TITLE
fix: Disallow `async_tiff.Store.ObjectStore` type to `GeoTIFF.open` to fix type checking

### DIFF
--- a/src/async_geotiff/_geotiff.py
+++ b/src/async_geotiff/_geotiff.py
@@ -26,7 +26,6 @@ from async_geotiff.enums import Compression, Interleaving, PhotometricInterpreta
 
 if TYPE_CHECKING:
     from async_tiff import GeoKeyDirectory, ImageFileDirectory, ObspecInput
-    from async_tiff.store import ObjectStore  # type: ignore # noqa: PGH003
     from pyproj.crs import CRS
 
 
@@ -127,7 +126,7 @@ class GeoTIFF(ReadMixin, FetchTileMixin, TransformMixin):
         cls,
         path: str,
         *,
-        store: ObjectStore | ObspecInput,
+        store: ObspecInput,
         prefetch: int = 32768,
         multiplier: float = 2.0,
     ) -> Self:


### PR DESCRIPTION
Because `async_tiff.store.ObjectStore` isn't found, that means the type checker (at least pylance) infers it as `Unknown` and thus accepts _any_ input into `store`

Closes #67 