### PR TITLE
chore: Reorder string ordering in image_list

### DIFF
--- a/tests/image_list.py
+++ b/tests/image_list.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 ALL_DATA_IMAGES: list[tuple[str, str]] = [
-    ("uint16_1band_lzw_block128_predictor2", "rasterio"),
-    ("uint8_1band_deflate_block128_unaligned", "rasterio"),
-    ("uint8_rgb_deflate_block64_cog", "rasterio"),
-    ("uint8_1band_lzma_block64", "rasterio"),
-    ("uint8_rgb_webp_block64_cog", "rasterio"),
-    ("uint8_rgba_webp_block64_cog", "rasterio"),
-    ("nlcd_landcover", "nlcd"),
-    ("sydney_airport_GEC", "umbra"),
+    ("nlcd", "nlcd_landcover"),
+    ("rasterio", "uint16_1band_lzw_block128_predictor2"),
+    ("rasterio", "uint8_1band_deflate_block128_unaligned"),
+    ("rasterio", "uint8_1band_lzma_block64"),
+    ("rasterio", "uint8_rgb_deflate_block64_cog"),
+    ("rasterio", "uint8_rgb_webp_block64_cog"),
+    ("rasterio", "uint8_rgba_webp_block64_cog"),
+    ("umbra", "sydney_airport_GEC"),
 ]
 """All fixtures where the data can be compared with rasterio."""
 
@@ -16,13 +16,13 @@ ALL_DATA_IMAGES: list[tuple[str, str]] = [
 ALL_TEST_IMAGES: list[tuple[str, str]] = [
     *ALL_DATA_IMAGES,
     # YCbCr is auto-decompressed by rasterio
-    ("maxar_opendata_yellowstone_visual", "vantor"),
+    ("vantor", "maxar_opendata_yellowstone_visual"),
     # we don't support LERC yet
-    ("float32_1band_lerc_block32", "rasterio"),
+    ("rasterio", "float32_1band_lerc_block32"),
 ]
 """All fixtures where we test metadata parsing."""
 
 ALL_MASKED_IMAGES: list[tuple[str, str]] = [
-    ("maxar_opendata_yellowstone_visual", "vantor"),
+    ("vantor", "maxar_opendata_yellowstone_visual"),
 ]
 """All fixtures that have a nodata mask."""

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -13,16 +13,16 @@ if TYPE_CHECKING:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     [
-        ("nlcd_landcover", "nlcd"),
+        ("nlcd", "nlcd_landcover"),
     ],
 )
 async def test_colormap(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     geotiff = await load_geotiff(file_name, variant=variant)
     colormap = geotiff.colormap

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -26,14 +26,14 @@ def projjson_schema() -> dict:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_TEST_IMAGES,
 )
 async def test_crs(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     geotiff = await load_geotiff(file_name, variant=variant)
     with load_rasterio(file_name, variant=variant) as rasterio_ds:
@@ -42,14 +42,14 @@ async def test_crs(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
-    [("nlcd_landcover", "nlcd")],
+    ("variant", "file_name"),
+    [("nlcd", "nlcd_landcover")],
 )
 async def test_crs_custom_projjson_schema(
     load_geotiff: LoadGeoTIFF,
     projjson_schema: dict,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     """Validate that a user-defined CRS produces valid PROJJSON."""
     geotiff = await load_geotiff(file_name, variant=variant)

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -16,14 +16,14 @@ if TYPE_CHECKING:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_DATA_IMAGES,
 )
 async def test_fetch(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     geotiff = await load_geotiff(file_name, variant=variant)
 
@@ -39,14 +39,14 @@ async def test_fetch(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_DATA_IMAGES,
 )
 async def test_fetch_overview(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     geotiff = await load_geotiff(file_name, variant=variant)
     overview = geotiff.overviews[0]
@@ -63,14 +63,14 @@ async def test_fetch_overview(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_MASKED_IMAGES,
 )
 async def test_mask(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     geotiff = await load_geotiff(file_name, variant=variant)
 
@@ -90,14 +90,14 @@ async def test_mask(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_MASKED_IMAGES,
 )
 async def test_mask_overview(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     geotiff = await load_geotiff(file_name, variant=variant)
     overview = geotiff.overviews[0]
@@ -118,14 +118,14 @@ async def test_mask_overview(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_DATA_IMAGES,
 )
 async def test_fetch_as_masked(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     geotiff = await load_geotiff(file_name, variant=variant)
 

--- a/tests/test_geotiff.py
+++ b/tests/test_geotiff.py
@@ -12,14 +12,14 @@ if TYPE_CHECKING:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_TEST_IMAGES,
 )
 async def test_ifd_info(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     geotiff = await load_geotiff(file_name, variant=variant)
 

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -19,14 +19,14 @@ if TYPE_CHECKING:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_DATA_IMAGES,
 )
 async def test_read_single_tile(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     """Test reading a window that fits within a single tile."""
     geotiff = await load_geotiff(file_name, variant=variant)
@@ -47,14 +47,14 @@ async def test_read_single_tile(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_DATA_IMAGES,
 )
 async def test_read_spanning_tiles(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     """Test reading a window that spans multiple tiles."""
     geotiff = await load_geotiff(file_name, variant=variant)
@@ -93,14 +93,14 @@ async def test_read_spanning_tiles(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_DATA_IMAGES,
 )
 async def test_read_overview(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     """Test reading from an overview level."""
     geotiff = await load_geotiff(file_name, variant=variant)
@@ -151,14 +151,14 @@ async def test_read_bounds_validation(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("file_name", "variant"),
+    ("variant", "file_name"),
     ALL_DATA_IMAGES,
 )
 async def test_read_full(
     load_geotiff: LoadGeoTIFF,
     load_rasterio: LoadRasterio,
-    file_name: str,
     variant: str,
+    file_name: str,
 ) -> None:
     geotiff = await load_geotiff(file_name, variant=variant)
     array = await geotiff.read()


### PR DESCRIPTION
Changes image names to be `(variant, fname)` so they can be better alphabetized