### PR TITLE
feat: Add `versions.get_versions` for debugging

### DIFF
--- a/src/async_geotiff/__init__.py
+++ b/src/async_geotiff/__init__.py
@@ -3,7 +3,7 @@
 [cogeo]: https://cogeo.org/
 """
 
-from . import exceptions
+from . import exceptions, versions
 from ._array import Array
 from ._geotiff import GeoTIFF
 from ._overview import Overview
@@ -19,4 +19,5 @@ __all__ = [
     "Window",
     "__version__",
     "exceptions",
+    "versions",
 ]

--- a/src/async_geotiff/versions.py
+++ b/src/async_geotiff/versions.py
@@ -1,0 +1,12 @@
+"""Version information."""
+
+from __future__ import annotations
+
+from async_tiff import __version__ as async_tiff_version
+
+from ._version import __version__
+
+
+def get_versions() -> dict[str, str]:
+    """Get package version information."""
+    return {"async-geotiff": __version__, "async-tiff": async_tiff_version}


### PR DESCRIPTION
I'd like to compare to some other projects like zarr/rasterio to see what public API they use for exposing package versions