### PR TITLE
feat: Add `.res` property to Overview

### DIFF
--- a/src/async_geotiff/_geotiff.py
+++ b/src/async_geotiff/_geotiff.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING, Self
@@ -350,16 +349,6 @@ class GeoTIFF(ReadMixin, FetchTileMixin, TransformMixin):
                 return PhotometricInterpretation.CIELAB
 
         return None
-
-    @property
-    def res(self) -> tuple[float, float]:
-        """Return the (width, height) of pixels in the units of its CRS."""
-        transform = self.transform
-        # For rotated images, resolution is the magnitude of the pixel size
-        # calculated from the transform matrix components
-        res_x = math.sqrt(transform.a**2 + transform.d**2)
-        res_y = math.sqrt(transform.b**2 + transform.e**2)
-        return (res_x, res_y)
 
     @property
     def shape(self) -> tuple[int, int]:

--- a/src/async_geotiff/_transform.py
+++ b/src/async_geotiff/_transform.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from math import floor
 from typing import TYPE_CHECKING, Literal, Protocol
 
@@ -47,6 +48,18 @@ class TransformMixin:
         col_frac, row_frac = inv_transform * (x, y)  # type: ignore[misc]
 
         return (op(row_frac), op(col_frac))
+
+    @property
+    def res(self: HasTransform) -> tuple[float, float]:
+        """Return the (width, height) of pixels in the units of its CRS."""
+        transform = self.transform
+
+        # For rotated images, resolution is the magnitude of the pixel size
+        # calculated from the transform matrix components
+        res_x = math.sqrt(transform.a**2 + transform.d**2)
+        res_y = math.sqrt(transform.b**2 + transform.e**2)
+
+        return (res_x, res_y)
 
     def xy(
         self: HasTransform,


### PR DESCRIPTION
This is also a general code cleanup. Because `res` only depends on the transform, we can put it on the `HasTransform` mixin