### PR TITLE
chore: Remove IFD reference from Tile

### DIFF
--- a/src/async_geotiff/_fetch.py
+++ b/src/async_geotiff/_fetch.py
@@ -89,7 +89,6 @@ class FetchTileMixin:
         return Tile(
             x=x,
             y=y,
-            _ifd=self._ifd,
             array=array,
         )
 
@@ -140,7 +139,6 @@ class FetchTileMixin:
             tile = Tile(
                 x=x,
                 y=y,
-                _ifd=self._ifd,
                 array=array,
             )
             final_tiles.append(tile)

--- a/src/async_geotiff/_tile.py
+++ b/src/async_geotiff/_tile.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from async_tiff import ImageFileDirectory
-
     from async_geotiff._array import Array
 
 
@@ -18,9 +16,6 @@ class Tile:
 
     y: int
     """The tile row index in the GeoTIFF or overview."""
-
-    _ifd: ImageFileDirectory
-    """A reference to the IFD this tile belongs to."""
 
     array: Array
     """The array data for this tile."""


### PR DESCRIPTION
I don't see if we need the `_ifd` reference for any reason