### PR TITLE
test: fix fixture dir discovery

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,18 +38,23 @@ class LoadRasterio(Protocol):
 
 
 @pytest.fixture(scope="session")
-def root_dir() -> Path:
-    root_dir = Path(__file__).parent.resolve()
+def fixtures_dir() -> Path:
+    python_root_dir = Path(__file__).parent.resolve()
 
-    while root_dir.name != "async-geotiff":
-        root_dir = root_dir.parent
+    while (
+        python_root_dir != Path("/")
+        and not (python_root_dir / "pyproject.toml").exists()
+    ):
+        python_root_dir = python_root_dir.parent
 
-    return root_dir
+    if not (python_root_dir / "pyproject.toml").exists():
+        raise RuntimeError("Couldn't find the fixtures dir")
+    return (python_root_dir / "fixtures").resolve()
 
 
 @pytest.fixture(scope="session")
-def fixture_store(root_dir) -> LocalStore:
-    return LocalStore(root_dir / "fixtures")
+def fixture_store(fixtures_dir) -> LocalStore:
+    return LocalStore(fixtures_dir)
 
 
 @pytest.fixture
@@ -69,7 +74,7 @@ def load_geotiff(fixture_store):
 
 
 @pytest.fixture
-def load_rasterio(root_dir):
+def load_rasterio(fixtures_dir):
     @contextmanager
     def _load(
         name: str,
@@ -78,7 +83,7 @@ def load_rasterio(root_dir):
         OVERVIEW_LEVEL: int | None = None,  # noqa: N803
         **kwargs: Any,  # noqa: ANN401
     ) -> Generator[DatasetReader, None, None]:
-        path = f"{root_dir}/fixtures/geotiff-test-data/"
+        path = f"{fixtures_dir}/geotiff-test-data/"
         if variant == "rasterio":
             path += "rasterio_generated/fixtures/"
         else:


### PR DESCRIPTION
# Description

The current conftest is walking the fs hierarchy up until it finds an `async-geotiff` folder. There is 2 problems with this approach:

- some build system / env don't unpack sources in a folder named `async-geotiff`. For instance the `nixpkgs` build system unpacks it in a `source/` dir
- there wasn't a real stop condition in case we didn't find this folder.

It's the same modification as for `async-tiff`.