### PR TITLE
ci: Use github app token for conventional commit labeling

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,11 +7,16 @@ on:
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
     steps:
+      - uses: actions/create-github-app-token@v3.0.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.DS_RELEASE_BOT_ID }}
+          private-key: ${{ secrets.DS_RELEASE_BOT_PRIVATE_KEY }}
+          permission-pull-requests: write
+
       - name: PR Conventional Commit Validation
         uses: ytanikin/pr-conventional-commits@1.5.2
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Same as https://github.com/developmentseed/async-tiff/pull/297