### PR TITLE
feat!: Allow public access to underlying IFD

### DIFF
--- a/src/async_geotiff/_fetch.py
+++ b/src/async_geotiff/_fetch.py
@@ -21,12 +21,12 @@ class HasTiffReference(HasTransform, Protocol):
     """Protocol for objects that hold a TIFF reference and can request tiles."""
 
     @property
-    def _ifd(self) -> ImageFileDirectory:
+    def ifd(self) -> ImageFileDirectory:
         """The data IFD for this image (index, IFD)."""
         ...
 
     @property
-    def _mask_ifd(self) -> ImageFileDirectory | None:
+    def mask_ifd(self) -> ImageFileDirectory | None:
         """The mask IFD for this image (index, IFD), if any."""
         ...
 
@@ -82,11 +82,11 @@ class FetchTileMixin:
             A Tile object containing the fetched tile data.
 
         """
-        tile_fut = self._ifd.fetch_tile(x, y)
+        tile_fut = self.ifd.fetch_tile(x, y)
 
         mask_data: Array | None = None
-        if self._mask_ifd is not None:
-            mask_fut = self._mask_ifd.fetch_tile(x, y)
+        if self.mask_ifd is not None:
+            mask_fut = self.mask_ifd.fetch_tile(x, y)
             tile, mask = await asyncio.gather(tile_fut, mask_fut)
             tile_data, mask_data = await asyncio.gather(tile.decode(), mask.decode())
         else:
@@ -101,7 +101,7 @@ class FetchTileMixin:
         array = RasterArray._create(  # noqa: SLF001
             data=tile_data,
             mask=mask_data,
-            planar_configuration=self._ifd.planar_configuration,
+            planar_configuration=self.ifd.planar_configuration,
             transform=tile_transform,
             geotiff=self._geotiff,
             # TODO: when we support fetching partial bands, we need to check if the
@@ -141,11 +141,11 @@ class FetchTileMixin:
             boundless: If False, clip edge tiles to the image bounds.
 
         """
-        tiles_fut = self._ifd.fetch_tiles(xy)
+        tiles_fut = self.ifd.fetch_tiles(xy)
 
         decoded_masks: list[Array | None] = [None] * len(xy)
-        if self._mask_ifd is not None:
-            masks_fut = self._mask_ifd.fetch_tiles(xy)
+        if self.mask_ifd is not None:
+            masks_fut = self.mask_ifd.fetch_tiles(xy)
             tiles, masks = await asyncio.gather(tiles_fut, masks_fut)
 
             decoded_tile_futs = [tile.decode() for tile in tiles]
@@ -170,7 +170,7 @@ class FetchTileMixin:
             array = RasterArray._create(  # noqa: SLF001
                 data=tile_data,
                 mask=mask_data,
-                planar_configuration=self._ifd.planar_configuration,
+                planar_configuration=self.ifd.planar_configuration,
                 transform=tile_transform,
                 geotiff=self._geotiff,
                 # TODO: when we support fetching partial bands, we need to check if the

--- a/src/async_geotiff/_geotiff.py
+++ b/src/async_geotiff/_geotiff.py
@@ -65,8 +65,13 @@ class GeoTIFF(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
     Some tags, like most geo tags, only exist on the primary IFD.
     """
 
-    _mask_ifd: ImageFileDirectory | None = None
-    """The mask IFD of the full-resolution GeoTIFF, if any.
+    mask_ifd: ImageFileDirectory | None = None
+    """Access to the underlying ImageFileDirectory for the mask associated with the
+    full-resolution image, if any.
+
+    !!! warning
+        This is for advanced users who need access to the underlying TIFF object.
+        Most users should only need to use async-geotiff's higher-level APIs.
     """
 
     _gkd: GeoKeyDirectory = field(init=False)
@@ -97,8 +102,13 @@ class GeoTIFF(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
         return alpha_band_idxs[0] if alpha_band_idxs else None
 
     @property
-    def _ifd(self) -> ImageFileDirectory:
-        """An alias for the primary IFD to satisfy _fetch protocol."""
+    def ifd(self) -> ImageFileDirectory:
+        """Access to the underlying ImageFileDirectory of the full-resolution image.
+
+        !!! warning
+            This is for advanced users who need access to the underlying TIFF object.
+            Most users should only need to use async-geotiff's higher-level APIs.
+        """
         return self._primary_ifd
 
     @property
@@ -159,7 +169,7 @@ class GeoTIFF(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
         if primary_mask_ifd := mask_ifds.get(
             (first_ifd.image_width, first_ifd.image_height),
         ):
-            object.__setattr__(self, "_mask_ifd", primary_mask_ifd)
+            object.__setattr__(self, "mask_ifd", primary_mask_ifd)
 
         # Build overviews, sorted by resolution (highest to lowest, i.e., largest first)
         # Sort by width * height descending
@@ -428,13 +438,13 @@ class GeoTIFF(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
     def tile_height(self) -> int:
         """The height in pixels per tile of the image."""
         # A TIFF with a single tile can omit tile_height
-        return self._ifd.tile_height or self._ifd.image_height
+        return self.ifd.tile_height or self.ifd.image_height
 
     @property
     def tile_width(self) -> int:
         """The width in pixels per tile of the image."""
         # A TIFF with a single tile can omit tile_width
-        return self._ifd.tile_width or self._ifd.image_width
+        return self.ifd.tile_width or self.ifd.image_width
 
     @property
     def transform(self) -> Affine:

--- a/src/async_geotiff/_geotiff.py
+++ b/src/async_geotiff/_geotiff.py
@@ -55,8 +55,12 @@ class GeoTIFF(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
     issues.
     """
 
-    _tiff: TIFF
-    """The underlying async-tiff TIFF instance that we wrap.
+    tiff: TIFF
+    """The underlying async-tiff [TIFF][async_tiff.TIFF] instance that we wrap.
+
+    !!! warning
+        This is for advanced users who need access to the underlying TIFF object.
+        Most users should only need to use async-geotiff's higher-level APIs.
     """
 
     _primary_ifd: ImageFileDirectory = field(init=False)
@@ -129,7 +133,7 @@ class GeoTIFF(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
             raise ValueError("TIFF does not contain any IFDs")
 
         # We use object.__setattr__ because the dataclass is frozen
-        object.__setattr__(self, "_tiff", tiff)
+        object.__setattr__(self, "tiff", tiff)
         object.__setattr__(self, "_primary_ifd", first_ifd)
         object.__setattr__(self, "_gkd", gkd)
         object.__setattr__(

--- a/src/async_geotiff/_overview.py
+++ b/src/async_geotiff/_overview.py
@@ -29,11 +29,22 @@ class Overview(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
     """The GeoKeyDirectory of the primary IFD.
     """
 
-    _ifd: ImageFileDirectory
-    """The IFD for this overview level."""
+    ifd: ImageFileDirectory
+    """Access to the underlying ImageFileDirectory of this overview level.
 
-    _mask_ifd: ImageFileDirectory | None
-    """The IFD for the mask associated with this overview level, if any."""
+    !!! warning
+        This is for advanced users who need access to the underlying TIFF object.
+        Most users should only need to use async-geotiff's higher-level APIs.
+    """
+
+    mask_ifd: ImageFileDirectory | None
+    """Access to the underlying ImageFileDirectory for the mask associated with this
+    overview level, if any.
+
+    !!! warning
+        This is for advanced users who need access to the underlying TIFF object.
+        Most users should only need to use async-geotiff's higher-level APIs.
+    """
 
     @classmethod
     def _create(
@@ -49,8 +60,8 @@ class Overview(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
         # We use object.__setattr__ because the dataclass is frozen
         object.__setattr__(instance, "_geotiff", geotiff)
         object.__setattr__(instance, "_gkd", gkd)
-        object.__setattr__(instance, "_ifd", ifd)
-        object.__setattr__(instance, "_mask_ifd", mask_ifd)
+        object.__setattr__(instance, "ifd", ifd)
+        object.__setattr__(instance, "mask_ifd", mask_ifd)
 
         return instance
 
@@ -67,7 +78,7 @@ class Overview(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
     @property
     def height(self) -> int:
         """The height of the overview in pixels."""
-        return self._ifd.image_height
+        return self.ifd.image_height
 
     @property
     def nodata(self) -> int | float | None:
@@ -77,14 +88,14 @@ class Overview(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
     @property
     def tile_height(self) -> int:
         """The height in pixels per tile of the overview."""
-        tile_height = self._ifd.tile_height
+        tile_height = self.ifd.tile_height
         assert tile_height is not None, "Constructor validated that images are tiled"  # noqa: S101
         return tile_height
 
     @property
     def tile_width(self) -> int:
         """The width in pixels per tile of the overview."""
-        tile_width = self._ifd.tile_width
+        tile_width = self.ifd.tile_width
         assert tile_width is not None, "Constructor validated that images are tiled"  # noqa: S101
         return tile_width
 
@@ -111,4 +122,4 @@ class Overview(ReadMixin, FetchTileMixin, TiledMixin, TransformMixin):
     @property
     def width(self) -> int:
         """The width of the overview in pixels."""
-        return self._ifd.image_width
+        return self.ifd.image_width

--- a/src/async_geotiff/_read.py
+++ b/src/async_geotiff/_read.py
@@ -97,7 +97,7 @@ async def read(
     # Create output array and mask array
     output_data = np.empty((num_bands, win.height, win.width), dtype=dtype)
     output_mask: NDArray[np.bool_] | None = None
-    if self._mask_ifd is not None:
+    if self.mask_ifd is not None:
         output_mask = np.ones((win.height, win.width), dtype=np.bool_)
 
     assemble_tiles(

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,7 @@ wheels = [
 
 [[package]]
 name = "async-geotiff"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "affine" },


### PR DESCRIPTION
### Change list

- Make `_ifd` and `_mask_ifd` public for the `GeoTIFF` and `Overview` classes.
	- So rename `_ifd` to `ifd` and `_mask_ifd` to `mask_ifd`.
	- This supports https://github.com/virtual-zarr/virtual-tiff/pull/95#issuecomment-4356076735 in virtual-tiff where they need access to the underlying `TIFF` object
- It's documented as a low-level API. Most users should be discouraged from accessing this