### PR TITLE
ci: Pin third party actions to SHA hashes

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -11,12 +11,12 @@ jobs:
       - uses: actions/create-github-app-token@v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.DS_RELEASE_BOT_ID }}
+          client-id: ${{ secrets.DS_RELEASE_BOT_ID }}
           private-key: ${{ secrets.DS_RELEASE_BOT_PRIVATE_KEY }}
           permission-pull-requests: write
 
       - name: PR Conventional Commit Validation
-        uses: ytanikin/pr-conventional-commits@1.5.2
+        uses: ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1 # 1.5.2
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/deploy-mkdocs.yml
+++ b/.github/workflows/deploy-mkdocs.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 
@@ -46,4 +46,4 @@ jobs:
           merge-multiple: true
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           submodules: "recursive"
 
       - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 
@@ -25,7 +25,7 @@ jobs:
         run: uv run --group docs mkdocs build --strict
 
       # Use ruff-action so we get annotations in the Github UI
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
 
   pytest:
     name: Pytest
@@ -39,7 +39,7 @@ jobs:
           submodules: "recursive"
 
       - name: Install a specific version of uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 


### PR DESCRIPTION
I ran:
```
npx pin-github-action .github/workflows/*.yml --allow actions/\*
```

Thanks to @lhoupert 

Closes https://github.com/developmentseed/async-geotiff/pull/142, closes #141