### PR TITLE
docs: Don't document private base classes

### DIFF
--- a/docs/api/geotiff.md
+++ b/docs/api/geotiff.md
@@ -1,4 +1,6 @@
 # GeoTIFF
 
 ::: async_geotiff.GeoTIFF
+    options:
+      show_bases: false
 ::: async_geotiff.Store

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,3 +1,5 @@
 # Overview
 
 ::: async_geotiff.Overview
+    options:
+      show_bases: false

--- a/docs/api/raster-array.md
+++ b/docs/api/raster-array.md
@@ -1,3 +1,5 @@
 # RasterArray
 
 ::: async_geotiff.RasterArray
+    options:
+      show_bases: false


### PR DESCRIPTION
The mixins and internal base classes aren't public, so there's no point to including them in the docs.


Before:

<img width="649" height="272" alt="image" src="https://github.com/user-attachments/assets/92c48a4e-84c7-4f76-9273-c43fb4278423" />

After:

<img width="526" height="232" alt="image" src="https://github.com/user-attachments/assets/b3d28a2e-f460-4abb-9910-bcebac14616f" />
