### PR TITLE
fix: Support parsing ESRI WKT String for ESRI-created custom CRS

### DIFF
--- a/src/async_geotiff/_crs.py
+++ b/src/async_geotiff/_crs.py
@@ -55,6 +55,11 @@ def crs_from_geo_keys(gkd: GeoKeyDirectory) -> CRS:
 
         return CRS.from_json_dict(crs)
 
+    if model_type == USER_DEFINED_CRS:
+        wkt = _esri_pe_string(gkd)
+        if wkt is not None:
+            return CRS.from_wkt(wkt)
+
     raise ValueError(f"Unsupported GeoTIFF model type: {model_type}")
 
 
@@ -83,7 +88,29 @@ def projjson_from_geo_keys(gkd: GeoKeyDirectory) -> dict:
 
         return crs
 
+    if model_type == USER_DEFINED_CRS:
+        wkt = _esri_pe_string(gkd)
+        if wkt is not None:
+            return CRS.from_wkt(wkt).to_json_dict()
+
     raise ValueError(f"Unsupported GeoTIFF model type: {model_type}")
+
+
+_ESRI_PE_STRING_PREFIX = "ESRI PE String ="
+
+
+def _esri_pe_string(gkd: GeoKeyDirectory) -> str | None:
+    """Extract a WKT string from an ``ESRI PE String = ...`` proj_citation.
+
+    GDAL stores the full ESRI WKT here when the GeoTIFF has no matching
+    EPSG code; pyproj parses it directly via :meth:`CRS.from_wkt`.
+    """
+    # The GeoTIFF spec defines no text-based CRS encoding; ``ESRI PE String =``
+    # is a de facto ArcGIS convention that GDAL/PROJ also read
+    citation = gkd.proj_citation
+    if citation is None or _ESRI_PE_STRING_PREFIX not in citation:
+        return None
+    return citation.split(_ESRI_PE_STRING_PREFIX, 1)[1].strip() or None
 
 
 def _geographic_projection(gkd: GeoKeyDirectory) -> int | dict:

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -43,7 +43,7 @@ async def test_crs(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("variant", "file_name"),
-    [("nlcd", "nlcd_landcover")],
+    [("nlcd", "nlcd_landcover"), ("source-coop-vizzuality", "hfp_2017_100m_v1-2_cog")],
 )
 async def test_crs_custom_projjson_schema(
     load_geotiff: LoadGeoTIFF,


### PR DESCRIPTION
Ref https://github.com/source-cooperative/cog-viewer/issues/8 and https://github.com/developmentseed/geotiff-test-data/pull/58. This GeoTIFF includes

GeoTIFF has `model_type`, `geographic_type`, `projected_type` geokeys. 

- If `model_type` is 1, check the `projected_type`
    - If `projected_type` is an int < 32767, it's an EPSG code; else CRS encoded in GeoKeys
- If `model_type` is 2, check the `geographic_type`
    - If `geographic_type` is an int < 32767, it's an EPSG code; else CRS encoded in GeoKeys
- If `model_type` is 32767, then the projection is "undefined", and there's a (hack? grandfathered?) way that uses ESRI WKT in the proj citation key.

This PR now supports the latter approach when `model_type` itself is 32767.

-----


## Summary

Some GeoTIFFs (e.g. source.coop's `hfp_2017_100m_v1-2_cog.tif`, Mollweide-projected Human Footprint data) set `GTModelTypeGeoKey = 32767` (`ModelTypeUserDefined`) instead of `1` (projected). Previously we raised `ValueError: Unsupported GeoTIFF model type: 32767` on these.

The fix adds a branch for `model_type == 32767` that reads the WKT from `PCSCitationGeoKey` when it's prefixed with `ESRI PE String =`, and parses it via `pyproj.CRS.from_wkt`.

## How user-defined CRSes are encoded in GeoTIFFs

There are two distinct cases to keep straight:

- **Common case** — `model_type = 1 (or 2)` + `projected_type/geographic_type = 32767`. The CRS is reconstructed from individual GeoKeys (datum, ellipsoid, projection method, parameters). This was already handled via `_build_user_defined_projected_projjson` / `_build_user_defined_geographic_projjson`.
- **Rare case** — `model_type = 32767`. Even the model type itself is user-defined. For the hfp file, `proj_coord_trans` and `projection` are both `None`, so there's no way to reconstruct the projection method from GeoKeys — the ESRI PE String is the only signal.

## Why ESRI PE String is "the only WKT prefix"

The GeoTIFF spec defines no text-based CRS encoding at all — when `model_type = 32767`, it expects the CRS to be reconstructable from individual GeoKeys, with citations as descriptive text only. `ESRI PE String =` is a de facto ArcGIS convention that GDAL/PROJ also read, and the only such prefix seen in the wild. It exists because ESRI's WKT dialect (`D_WGS_1984` vs `WGS 84`, etc.) doesn't roundtrip through GeoKeys cleanly, so ArcGIS added the prefix as a lossless escape hatch.

The other structured citations GDAL parses (`GCS Name = X|Datum = Y|...`) are *not* alternative WKT encodings — they're key/value metadata hints that augment GeoKey-derived CRS info, which we already parse in `_parse_geog_citation`.

## Test plan

- [x] `test_crs_custom_projjson_schema[source-coop-vizzuality-hfp_2017_100m_v1-2_cog]` now passes
- [x] `test_crs_custom_projjson_schema[nlcd-nlcd_landcover]` still passes (no regression)
- [x] Full suite green: 372 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)